### PR TITLE
Remove avatars from forums page

### DIFF
--- a/css/stylesheet.css
+++ b/css/stylesheet.css
@@ -47,6 +47,10 @@ padding-top: 0px;
 text-align: right;
 }
 
+ul.forums li.row .lastpostavatar {
+  display: none;
+}
+
 ul.topics li.row .posteravatar {
   display: none;
 }
@@ -61,4 +65,16 @@ ul.topics li.row .lastpost {
 
 ul.topics li.row.sticky {
   background-color: #f9f9f9;
+}
+
+ul.topiclist dd.posts {
+  margin-right: 0px;
+}
+
+ul.topiclist li.header dd.lastpost {
+    margin-left: 20px;
+}
+
+ul.topiclist dd.lastpost {
+    padding-left: 0px;
 }


### PR DESCRIPTION
Removes the avatars from the main/forums list page.

<img width="328" alt="screen shot 2017-12-26 at 3 51 41 pm" src="https://user-images.githubusercontent.com/4721755/34364597-498b3a72-ea55-11e7-8cf4-96051014e709.png">

Topics and Posts counters are not aligned (and they haven't been since I started tinkering). Maybe that's the next thing...